### PR TITLE
Fix ImGuiKey bug on CCKeyboardDispatcher

### DIFF
--- a/src/hooks.cpp
+++ b/src/hooks.cpp
@@ -85,7 +85,9 @@ class $modify(CCKeyboardDispatcher) {
 		}
 		const auto imKey = cocosToImGuiKey(key);
 		if (imKey != ImGuiKey_None) {
-			ImGui::GetIO().AddKeyEvent(imKey, down);
+			// im not sure why but this fixes the enter button on input
+			ImGui::GetIO().AddKeyEvent(imKey, true);
+            		ImGui::GetIO().AddKeyEvent(imKey, false);
 		}
 		return false;
 	}

--- a/src/hooks.cpp
+++ b/src/hooks.cpp
@@ -87,7 +87,7 @@ class $modify(CCKeyboardDispatcher) {
 		if (imKey != ImGuiKey_None) {
 			// im not sure why but this fixes the enter button on input
 			ImGui::GetIO().AddKeyEvent(imKey, true);
-            		ImGui::GetIO().AddKeyEvent(imKey, false);
+			ImGui::GetIO().AddKeyEvent(imKey, false);
 		}
 		return false;
 	}


### PR DESCRIPTION
For some reason CCKeyboardDispatcher doesn't give `false` for `down` at first, leading to ImGui pressing `imKey` everytime (because its `true` and was never given `false`), meaning elements like ::InputFloat will keep on pressing `Enter` or any other elements that use CTRL or any other ImGui key.

This uses a similar method found in https://github.com/matcool/gd-imgui-cocos/blob/3c7f7c2632c9a7cb47a84ed7db06f0ea408c62eb/src/hooks.cpp#L55-L56

Basically for example, let's say I used `ImGui::InputInt("My Input", &value, 10);`

### Without changes from this PR
1. User opens ImGui Window
2. User clicks on the input field for "My Input"
3. User types in a number and presses `Enter` on their keyboard (ImGui sees `Enter` as being pressed)
4. User wants to change the input field for "My Input" again
5. ImGui assumes that the `Enter` key is still being pressed, so it assumes the user finished their input.
6. User is not able to change the input anymore because of this.

### With changes from this PR
1. User opens ImGui Window
2. User clicks on the input field for "My Input"
3. User types in a number and presses `Enter` on their keyboard (ImGui sees `Enter` as being pressed, then sees `Enter` as not being pressed)
4. User wants to change the input field for "My Input" again
5. Go to step 2

Let me know if there are changes to be made.