### PR TITLE
fix HAS_IMGUI compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ target_sources(imgui-cocos INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/src/hooks.cpp
 )
 
+target_include_directories(imgui-cocos INTERFACE ${imgui_SOURCE_DIR} include)
+
 if (APPLE)
     target_sources(imgui-cocos INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/src/retina.mm)
     set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/src/retina.mm PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
@@ -25,8 +27,6 @@ if (NOT HAS_IMGUI)
     endif()
 
     CPMAddPackage("gh:ocornut/imgui#${IMGUI_VERSION}")
-
-    target_include_directories(imgui-cocos INTERFACE ${imgui_SOURCE_DIR} include)
 
     target_sources(imgui-cocos INTERFACE
         ${imgui_SOURCE_DIR}/imgui.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ target_sources(imgui-cocos INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/src/hooks.cpp
 )
 
-target_include_directories(imgui-cocos INTERFACE ${imgui_SOURCE_DIR} include)
+target_include_directories(imgui-cocos INTERFACE include)
 
 if (APPLE)
     target_sources(imgui-cocos INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/src/retina.mm)
@@ -27,6 +27,8 @@ if (NOT HAS_IMGUI)
     endif()
 
     CPMAddPackage("gh:ocornut/imgui#${IMGUI_VERSION}")
+
+    target_include_directories(imgui-cocos INTERFACE ${imgui_SOURCE_DIR})
 
     target_sources(imgui-cocos INTERFACE
         ${imgui_SOURCE_DIR}/imgui.cpp


### PR DESCRIPTION
`imgui-cocos.hpp` is not included for some reason when HAS_IMGUI is set to ON, which makes it impossible to include and use the library