### PR TITLE
add a way to reload imgui

### DIFF
--- a/include/imgui-cocos.hpp
+++ b/include/imgui-cocos.hpp
@@ -18,6 +18,7 @@ private:
 	cocos2d::CCTexture2D* m_fontTexture = nullptr;
 	bool m_initialized = false;
 	bool m_visible = true;
+	bool m_reloading = false;
 	std::function<void()> m_setupCall, m_drawCall;
 	InputMode m_inputMode = InputMode::Default;
 
@@ -40,6 +41,9 @@ public:
 	ImGuiCocos& setup();
 
 	ImGuiCocos& draw(std::function<void()> fun);
+
+	// used to reinitialize imgui context
+	void reload();
 
 	void toggle();
 	bool isVisible();

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -93,6 +93,10 @@ void ImGuiCocos::destroy() {
 	m_initialized = false;
 }
 
+void ImGuiCocos::reload() {
+	m_reloading = true;
+}
+
 #ifndef GEODE_IS_MACOS
 
 float ImGuiCocos::retinaFactor() {
@@ -127,7 +131,7 @@ void ImGuiCocos::drawFrame() {
 	if (!m_initialized || !m_visible) return;
 
 	ccGLBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-	
+
 	// starts a new frame for imgui
 	this->newFrame();
 	ImGui::NewFrame();
@@ -138,6 +142,13 @@ void ImGuiCocos::drawFrame() {
 	// renders the triangles onto the screen
 	ImGui::Render();
 	this->renderFrame();
+
+	// reload imgui context if requested
+	if (m_reloading) {
+		this->destroy();
+		this->setup();
+		m_reloading = false;
+	}
 }
 
 void ImGuiCocos::newFrame() {


### PR DESCRIPTION
Added a "ImGuiCocos::reload()" method, which allows user to reload the context. Can be used, for example, to refresh fonts loaded in the init callback.