### PR TITLE
name hooks, fix arrow keys, use keyboard event, fix clipboard

### DIFF
--- a/src/hooks.cpp
+++ b/src/hooks.cpp
@@ -11,7 +11,7 @@
 using namespace geode::prelude;
 
 #ifndef GEODE_IS_IOS
-class $modify(CCMouseDispatcher) {
+class $modify(ImGuiCocosCCMouseDispatcher, CCMouseDispatcher) {
 	bool dispatchScrollMSG(float y, float x) {
 		if (!ImGuiCocos::get().isInitialized())
 			return CCMouseDispatcher::dispatchScrollMSG(y, x);
@@ -47,7 +47,7 @@ class $modify(CCMouseDispatcher) {
 	#define IF_2_208(...)
 #endif
 
-class $modify(CCIMEDispatcher) {
+class $modify(ImGuiCocosCCIMEDispatcher, CCIMEDispatcher) {
 	void dispatchInsertText(const char* text, int len IF_2_2(, enumKeyCodes keys)) {
 		if (!ImGuiCocos::get().isInitialized())
 			return CCIMEDispatcher::dispatchInsertText(text, len IF_2_2(, keys));
@@ -56,6 +56,16 @@ class $modify(CCIMEDispatcher) {
 		if (!io.WantCaptureKeyboard) {
 			CCIMEDispatcher::dispatchInsertText(text, len IF_2_2(, keys));
 		}
+
+#if GEODE_COMP_GD_VERSION >= 22000
+		switch (keys) {
+			case KEY_Left:
+			case KEY_Right:
+				return; // cocos sends 'a' text alongside the keycode
+			default: break;
+		}
+#endif
+
 		std::string str(text, len);
 		io.AddInputCharactersUTF8(str.c_str());
 	}
@@ -88,14 +98,24 @@ ImGuiKey cocosToImGuiKey(cocos2d::enumKeyCodes key) {
 		case KEY_Right: return ImGuiKey_RightArrow;
 
 		case KEY_Control: return ImGuiKey_LeftCtrl;
+		case KEY_LeftControl: return ImGuiKey_LeftCtrl;
+		case KEY_RightControl: return ImGuiKey_RightCtrl;
 		case KEY_LeftWindowsKey: return ImGuiKey_LeftSuper;
+		case KEY_RightWindowsKey: return ImGuiKey_RightSuper;
 		case KEY_Shift: return ImGuiKey_LeftShift;
+		case KEY_LeftShift: return ImGuiKey_LeftShift;
+		case KEY_RightShift: return ImGuiKey_RightShift;
 		case KEY_Alt: return ImGuiKey_LeftAlt;
+		case KEY_LeftMenu: return ImGuiKey_LeftAlt;
+		case KEY_RightMenu: return ImGuiKey_RightAlt;
 		case KEY_Enter: return ImGuiKey_Enter;
 
 		case KEY_Home: return ImGuiKey_Home;
 		case KEY_End: return ImGuiKey_End;
 		case KEY_Delete: return ImGuiKey_Delete;
+		case KEY_Backspace: return ImGuiKey_Backspace;
+		case KEY_Tab: return ImGuiKey_Tab;
+		case KEY_Escape: return ImGuiKey_Escape;
 
 		default: return ImGuiKey_None;
 	}
@@ -106,29 +126,36 @@ bool shouldBlockInput() {
 	return inst.isVisible() && inst.getInputMode() == ImGuiCocos::InputMode::Blocking;
 }
 
-#ifndef GEODE_IS_IOS
-class $modify(CCKeyboardDispatcher) {
-	bool dispatchKeyboardMSG(enumKeyCodes key, bool down IF_2_2(, bool repeat) IF_2_208(, double time)) {
+$execute {
+	KeyboardInputEvent().listen([](auto& evt) {
 		if (!ImGuiCocos::get().isInitialized())
-			return CCKeyboardDispatcher::dispatchKeyboardMSG(key, down IF_2_2(, repeat) IF_2_208(, time));
+			return ListenerResult::Propagate;
 
 		const bool shouldEatInput = ImGui::GetIO().WantCaptureKeyboard || shouldBlockInput();
-		if (shouldEatInput || !down) {
-			const auto imKey = cocosToImGuiKey(key);
+		const bool isDown = evt.action != KeyboardInputData::Action::Release;
+		if (shouldEatInput && evt.key != KEY_None) {
+			const auto imKey = cocosToImGuiKey(evt.key);
 			if (imKey != ImGuiKey_None) {
-				ImGui::GetIO().AddKeyEvent(imKey, down);
+				ImGui::GetIO().AddKeyEvent(imKey, isDown);
+
+				// handle pasting
+				if (isDown && evt.key == KEY_V
+			#if GEODE_IS_MACOS
+					&& (evt.modifiers & KeyboardModifier::Super)
+			#else
+					&& (evt.modifiers & KeyboardModifier::Control)
+			#endif
+				) {
+					ImGui::GetIO().AddInputCharactersUTF8(clipboard::read().c_str());
+				}
 			}
 		}
-		if (shouldEatInput) {
-			return false;
-		} else {
-			return CCKeyboardDispatcher::dispatchKeyboardMSG(key, down IF_2_2(, repeat) IF_2_208(, time));
-		}
-	}
-};
-#endif
 
-class $modify(CCTouchDispatcher) {
+		return shouldEatInput;
+	}).leak();
+}
+
+class $modify(ImGuiCocosCCTouchDispatcher, CCTouchDispatcher) {
 	void touches(CCSet* touches, CCEvent* event, unsigned int type) {
 		if (!ImGuiCocos::get().isInitialized() || !touches)
 			return CCTouchDispatcher::touches(touches, event, type);
@@ -181,7 +208,7 @@ class $modify(CCTouchDispatcher) {
 
 #include <Geode/modify/CCEGLView.hpp>
 
-class $modify(CCEGLView) {
+class $modify(ImGuiCocosCCEGLView, CCEGLView) {
 #ifdef IMGUI_COCOS_HOOK_EARLY
 	static void onModify(auto& self) {
 		if (!self.setHookPriorityPre("cocos2d::CCEGLView::swapBuffers", Priority::Early)) {
@@ -213,7 +240,7 @@ class $modify(CCEGLView) {
 
 #include <Geode/modify/CCDirector.hpp>
 
-class $modify(CCDirector) {
+class $modify(ImGuiCocosCCDirector, CCDirector) {
 	void drawScene() {
 		CCDirector::drawScene();
 		if (ImGuiCocos::get().isInitialized())

--- a/src/hooks.cpp
+++ b/src/hooks.cpp
@@ -127,6 +127,19 @@ bool shouldBlockInput() {
 }
 
 #if GEODE_COMP_GD_VERSION >= 22080
+#ifdef GEODE_IS_MACOS
+// this is a workaround for ListenerResult::Stop preventing dispatchInsertText from getting called on macOS
+static bool s_shouldEatInput = false;
+
+class $modify(ImGuiCocosCCKeyboardDispatcher, CCKeyboardDispatcher) {
+	bool dispatchKeyboardMSG(enumKeyCodes key, bool down, bool repeat, double time) {
+		if (!s_shouldEatInput)
+			return CCKeyboardDispatcher::dispatchKeyboardMSG(key, down, repeat, time);
+		s_shouldEatInput = false;
+		return false;
+	}
+};
+#endif
 $execute {
 	KeyboardInputEvent().listen([](auto& evt) {
 		if (!ImGuiCocos::get().isInitialized())
@@ -152,12 +165,17 @@ $execute {
 			}
 		}
 
+	#ifdef GEODE_IS_MACOS
+		s_shouldEatInput = shouldEatInput;
+		return ListenerResult::Propagate;
+	#else
 		return shouldEatInput;
+	#endif
 	}).leak();
 }
 #else
 #ifndef GEODE_IS_IOS
-class $modify(CCKeyboardDispatcher) {
+class $modify(ImGuiCocosCCKeyboardDispatcher, CCKeyboardDispatcher) {
 	bool dispatchKeyboardMSG(enumKeyCodes key, bool down IF_2_2(, bool repeat) IF_2_208(, double time)) {
 		if (!ImGuiCocos::get().isInitialized())
 			return CCKeyboardDispatcher::dispatchKeyboardMSG(key, down IF_2_2(, repeat) IF_2_208(, time));

--- a/src/hooks.cpp
+++ b/src/hooks.cpp
@@ -126,6 +126,7 @@ bool shouldBlockInput() {
 	return inst.isVisible() && inst.getInputMode() == ImGuiCocos::InputMode::Blocking;
 }
 
+#if GEODE_COMP_GD_VERSION >= 22080
 $execute {
 	KeyboardInputEvent().listen([](auto& evt) {
 		if (!ImGuiCocos::get().isInitialized())
@@ -154,6 +155,29 @@ $execute {
 		return shouldEatInput;
 	}).leak();
 }
+#else
+#ifndef GEODE_IS_IOS
+class $modify(CCKeyboardDispatcher) {
+	bool dispatchKeyboardMSG(enumKeyCodes key, bool down IF_2_2(, bool repeat) IF_2_208(, double time)) {
+		if (!ImGuiCocos::get().isInitialized())
+			return CCKeyboardDispatcher::dispatchKeyboardMSG(key, down IF_2_2(, repeat) IF_2_208(, time));
+
+		const bool shouldEatInput = ImGui::GetIO().WantCaptureKeyboard || shouldBlockInput();
+		if (shouldEatInput || !down) {
+			const auto imKey = cocosToImGuiKey(key);
+			if (imKey != ImGuiKey_None) {
+				ImGui::GetIO().AddKeyEvent(imKey, down);
+			}
+		}
+		if (shouldEatInput) {
+			return false;
+		} else {
+			return CCKeyboardDispatcher::dispatchKeyboardMSG(key, down IF_2_2(, repeat) IF_2_208(, time));
+		}
+	}
+};
+#endif
+#endif
 
 class $modify(ImGuiCocosCCTouchDispatcher, CCTouchDispatcher) {
 	void touches(CCSet* touches, CCEvent* event, unsigned int type) {

--- a/src/hooks.cpp
+++ b/src/hooks.cpp
@@ -126,7 +126,10 @@ bool shouldBlockInput() {
 	return inst.isVisible() && inst.getInputMode() == ImGuiCocos::InputMode::Blocking;
 }
 
+// Use Geode 5.0.0 keyboard event system
+// would use a geode version check here, but there is no macro for it..
 #if GEODE_COMP_GD_VERSION >= 22080
+
 #ifdef GEODE_IS_MACOS
 // this is a workaround for ListenerResult::Stop preventing dispatchInsertText from getting called on macOS
 static bool s_shouldEatInput = false;
@@ -140,6 +143,7 @@ class $modify(ImGuiCocosCCKeyboardDispatcher, CCKeyboardDispatcher) {
 	}
 };
 #endif
+
 $execute {
 	KeyboardInputEvent().listen([](auto& evt) {
 		if (!ImGuiCocos::get().isInitialized())
@@ -174,6 +178,7 @@ $execute {
 	}).leak();
 }
 #else
+// otherwise, hook dispatchKeyboardMSG
 #ifndef GEODE_IS_IOS
 class $modify(ImGuiCocosCCKeyboardDispatcher, CCKeyboardDispatcher) {
 	bool dispatchKeyboardMSG(enumKeyCodes key, bool down IF_2_2(, bool repeat) IF_2_208(, double time)) {

--- a/src/hooks.cpp
+++ b/src/hooks.cpp
@@ -147,7 +147,7 @@ $execute {
 
 		const bool shouldEatInput = ImGui::GetIO().WantCaptureKeyboard || shouldBlockInput();
 		const bool isDown = evt.action != KeyboardInputData::Action::Release;
-		if (shouldEatInput && evt.key != KEY_None) {
+		if (shouldEatInput || !isDown) {
 			const auto imKey = cocosToImGuiKey(evt.key);
 			if (imKey != ImGuiKey_None) {
 				ImGui::GetIO().AddKeyEvent(imKey, isDown);

--- a/src/hooks.cpp
+++ b/src/hooks.cpp
@@ -141,7 +141,7 @@ $execute {
 
 				// handle pasting
 				if (isDown && evt.key == KEY_V
-			#if GEODE_IS_MACOS
+			#ifdef GEODE_IS_MACOS
 					&& (evt.modifiers & KeyboardModifier::Super)
 			#else
 					&& (evt.modifiers & KeyboardModifier::Control)


### PR DESCRIPTION
- named the modify classes for nicer crashlog symbols
- fixed arrow keys printing 'aaaaaaaa'
- removed CCKeyboardDispatcher hook, replaced with Geode v5 keyboard event (for 2.208)
- fixed clipboard not working at all