### PR TITLE
Fix typo in KEY_RightControl case

### DIFF
--- a/src/hooks.cpp
+++ b/src/hooks.cpp
@@ -99,7 +99,7 @@ ImGuiKey cocosToImGuiKey(cocos2d::enumKeyCodes key) {
 
 		case KEY_Control: return ImGuiKey_LeftCtrl;
 		case KEY_LeftControl: return ImGuiKey_LeftCtrl;
-		case KEY_RightControl: return ImGuiKey_RightCtrl;
+		case KEY_RightContol: return ImGuiKey_RightCtrl;
 		case KEY_LeftWindowsKey: return ImGuiKey_LeftSuper;
 		case KEY_RightWindowsKey: return ImGuiKey_RightSuper;
 		case KEY_Shift: return ImGuiKey_LeftShift;


### PR DESCRIPTION
Geode has no `KEY_RightControl`. They call it `KEY_RightContol`

>     KEY_RightContol = 0xA3, // typo from original cocos

https://github.com/geode-sdk/geode/blob/2c84a6c326075bb93079fdfbb4d790b5d40d0141/loader/include/Geode/cocos/robtop/keyboard_dispatcher/CCKeyboardDelegate.h#L130